### PR TITLE
Remove "Download stable" button, update networking description 

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
                     <span style="font-size: 12px;">An open source fighting game engine that supports M.U.G.E.N resources</span>
                 </div>
                 <div class="buttons-container">
-                    <a class="releases-button nightly-button" href="https://github.com/ikemen-engine/Ikemen-GO/releases/tag/nightly"><p id="version-nightly">Download nightly build</p></a>
-                    <a class="releases-button" href="https://github.com/ikemen-engine/Ikemen-GO/releases/latest"><p id="version">Download stable build</p></a>
+                    <a class="releases-button" href="https://github.com/ikemen-engine/Ikemen-GO/releases/tag/nightly"><p id="version-nightly">Download nightly build</p></a>
+                    <!--<a class="releases-button" href="https://github.com/ikemen-engine/Ikemen-GO/releases/latest"><p id="version">Download stable build</p></a>-->
                 </div>
-                <span style="font-size: 12px;">Download buttons not working? <a href="https://github.com/ikemen-engine/Ikemen-GO/releases/">Click here</a> for the releases page.</span>
+                <span style="font-size: 12px;">Looking for stable builds (or downloads not working)? You can find them <a href="https://github.com/ikemen-engine/Ikemen-GO/releases/">here</a>.</span>
             </div>
         </div>
 
@@ -47,7 +47,7 @@
                 <div class="feature">
                     <img src="./resources/netplay.png"></img>
                     <h3>Network Play</h3>
-                    <p>Delay-based netcode makes it possible for two players to connect to each other over the Internet and duke it out in a versus match, or play cooperatively in arcade or survival mode.</p>
+                    <p>Rollback and delay-based netcode makes it possible for two players to connect to each other over the Internet and duke it out in a versus match, or play cooperatively in arcade or survival mode.</p>
                 </div>
 
                 <div class="feature">

--- a/index.js
+++ b/index.js
@@ -26,11 +26,12 @@ async function set_release_data() {
         nightly_url = "https://github.com/ikemen-engine/Ikemen-GO/releases/download/nightly/Ikemen_GO-dev-" + os + ".zip";
     }
 
-    document.getElementsByClassName("releases-button")[0].href = release_url;
-    document.getElementsByClassName("nightly-button")[0].href = nightly_url;
+    //document.getElementsByClassName("releases-button")[0].href = release_url;
+    //document.getElementsByClassName("nightly-button")[0].href = nightly_url;
+	document.getElementsByClassName("releases-button")[0].href = nightly_url;
 
     if (name[0] == "v") {name = name.slice(1)}
-    document.getElementById("version").innerText = "Download stable build: " + name;
+    //document.getElementById("version").innerText = "Download stable build: " + name;
 }
 
 set_release_data()


### PR DESCRIPTION
Per discussion on the Discord. I've only commented them out in case this changes down the road and we need to re-enable it later.

<img width="1365" height="456" alt="image" src="https://github.com/user-attachments/assets/ad13235e-56e9-4c9c-b6b9-5c58acd2c4d6" />
